### PR TITLE
fix(oxtrust): change cert to idpcert

### DIFF
--- a/oxTrust/server/src/main/java/org/gluu/oxtrust/action/PassportProvidersAction.java
+++ b/oxTrust/server/src/main/java/org/gluu/oxtrust/action/PassportProvidersAction.java
@@ -138,7 +138,7 @@ public class PassportProvidersAction implements Serializable {
 						new OptionEntry("identifierFormat", "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"));
 				this.options.add(new OptionEntry("authnRequestBinding", "HTTP-POST"));
 				this.options.add(new OptionEntry(ISSUER, DEFAULT_ISSUER));
-				this.options.add(new OptionEntry("cert", ""));
+				this.options.add(new OptionEntry("idpCert", ""));
 			}
 			if (type.equalsIgnoreCase(providerTypes[1])) {
 				String scopes = "[\"openid\",\"email\",\"profile\"]";

--- a/oxTrust/server/src/main/webapp/passport/addProvider.xhtml
+++ b/oxTrust/server/src/main/webapp/passport/addProvider.xhtml
@@ -63,7 +63,7 @@
              $(".MappingId").val("oxd-default");
             }
             if( type == "saml"){
-             $(".PassportStrategyId").val("passport-saml");
+             $(".PassportStrategyId").val("@node-saml/passport-saml");
              $(".MappingId").val("saml_ldap_profile");
             }
             if( type == "oauth"){


### PR DESCRIPTION
#4 
Changed the provider option 'cert' -> 'idpCert' and changed the strategy for saml  'passport-saml' -> '@node-saml/passport-saml' here is the screenshot.
![image](https://github.com/user-attachments/assets/71a745a4-68bb-4af1-addb-c28fb16fd7c5)
