### PR TITLE
fix(oxtrust): duplicated fields for regex pattern on attribute page

### DIFF
--- a/oxTrust/server/src/main/webapp/WEB-INF/incl/attribute/attributeForm.xhtml
+++ b/oxTrust/server/src/main/webapp/WEB-INF/incl/attribute/attributeForm.xhtml
@@ -221,12 +221,6 @@
 							<f:validateLongRange minimum="1" maximum="10000" />
 						</h:inputText>
 					</ox:decorate>
-					<ox:decorate id="regex" label="#{msgs['attribute.regexPattern']}">
-						<h:inputText styleClass="form-control regexPatternField"
-							value="#{_attribute.attributeValidation.regexp}" size="40"
-							maxlength="4000" id="regexid"
-							disabled="#{not _attributeAction.canEdit()}" />
-					</ox:decorate>
 
 					<ox:decorate id="status" label="#{msgs['attribute.status']}">
 						<h:selectOneMenu styleClass="form-control rounded statusValue"


### PR DESCRIPTION
removed duplicate regex field on attribute page

image with duplicate regex:

![image](https://github.com/user-attachments/assets/919660cb-88c5-48d5-b451-5946f0d08e70)


image after fix:

![image](https://github.com/user-attachments/assets/b64fb732-4859-479b-ad83-b88ba4efdd17)

