### PR TITLE
fix(ce-setup): jetty service start script waits service started

### DIFF
--- a/community-edition-setup/static/system/initd/jetty.sh
+++ b/community-edition-setup/static/system/initd/jetty.sh
@@ -152,7 +152,7 @@ return 1
 
 started()
 {
-  # wait for 60s to see "STARTED" in PID file, needs jetty-started.xml as argument
+  # wait for 60s to see "STARTED" in PID file
   for ((T = 0; T < $(($3 / 4)); T++))
   do
     sleep 4
@@ -517,17 +517,12 @@ case "$ACTION" in
 
     fi
 
-    if expr "${JETTY_ARGS[*]}" : '.*jetty-started.xml.*' >/dev/null
+    if started "$JETTY_STATE" "$JETTY_PID" "$JETTY_START_TIMEOUT"
     then
-      if started "$JETTY_STATE" "$JETTY_PID" "$JETTY_START_TIMEOUT"
-      then
-        echo "OK `date`"
-      else
-        echo "FAILED `date`"
-        exit 1
-      fi
+      echo "OK `date`"
     else
-      echo "ok `date`"
+      echo "FAILED `date`"
+      exit 1
     fi
 
     ;;


### PR DESCRIPTION
**Issue**
<!-- Please link the issue here -->
Closes #199

**Work scope**
<!-- Please mark the areas that need to be worked on. -->
- [x] Services
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Other

**Describe the bug/Feature**
<!-- A clear and concise description of what the bug is. -->

**If this is a bug how can it be reproduced**

Steps to reproduce the behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See error

**Expected behavior**
<!-- A clear and concise description of what you expected to happen. -->

**Screenshots**
<!-- If applicable, add screenshots to help explain. -->

**Additional context**
<!-- Add any other context about the problem here. -->

**Work scope progress**

Please select the scopes that are completed. This must match the work scope above by the end of the development.

- [x] Services
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Other
