### PR TITLE
chore(oxauth): improved logging during existing session update #213

### DIFF
--- a/oxAuth/Server/src/main/java/org/gluu/oxauth/authorize/ws/rs/AuthorizeRestWebServiceImpl.java
+++ b/oxAuth/Server/src/main/java/org/gluu/oxauth/authorize/ws/rs/AuthorizeRestWebServiceImpl.java
@@ -846,7 +846,7 @@ public class AuthorizeRestWebServiceImpl implements AuthorizeRestWebService {
                     sessionUser.setState(SessionIdState.UNAUTHENTICATED);
                     sessionUser.getSessionAttributes().put("prompt", org.gluu.oxauth.model.util.StringUtils.implode(prompts, " "));
                     if (!sessionIdService.persistSessionId(sessionUser)) {
-                        log.trace("Unable persist session_id, try to update it.");
+                        log.info("Unable persist session_id, try to update it.");
                         sessionIdService.updateSessionId(sessionUser);
                     }
 

--- a/oxAuth/Server/src/main/java/org/gluu/oxauth/service/SessionIdService.java
+++ b/oxAuth/Server/src/main/java/org/gluu/oxauth/service/SessionIdService.java
@@ -601,7 +601,7 @@ public class SessionIdService {
                 sessionId.setPersisted(true);
                 sessionId.setExpirationDate(expiration.getFirst());
                 sessionId.setTtl(expiration.getSecond());
-                log.trace("sessionIdAttributes: " + sessionId.getPermissionGrantedMap());
+                log.trace("sessionIdAttributes: {}", sessionId.getPermissionGrantedMap());
                 if (appConfiguration.getSessionIdPersistInCache()) {
                     cacheService.put(expiration.getSecond(), sessionId.getDn(), sessionId);
                 } else {
@@ -611,7 +611,8 @@ public class SessionIdService {
                 return true;
             }
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            // log exception in TRACE by intention because this method can be called over existing session by design, #213
+            log.trace(e.getMessage(), e);
         }
 
         return false;


### PR DESCRIPTION
**Issue**

chore(oxauth): improved logging during existing session update 

Closes #213

**Work scope**
- [x] Services

**Describe the bug/Feature**
Improved logging to avoid confusing that may be caused by exception during session persistence which is followed by update call.
See https://github.com/GluuFederation/gluu4/issues/213

