### PR TITLE
fix(oxtrsut): don't udpate scope id on save

### DIFF
--- a/oxTrust/server/src/main/java/org/gluu/oxtrust/action/UpdateScopeAction.java
+++ b/oxTrust/server/src/main/java/org/gluu/oxtrust/action/UpdateScopeAction.java
@@ -226,7 +226,9 @@ public class UpdateScopeAction implements Serializable {
 	public String save() throws Exception {
 		try {
 			this.scope.setDisplayName(this.scope.getDisplayName().trim());
-			this.scope.setId(this.scope.getDisplayName());
+			if (this.scope.getId() == null) {
+				this.scope.setId(this.scope.getDisplayName());
+			}
 			updateDynamicScripts();
 			updateAuthorizationPolicies();
 			updateClaims();


### PR DESCRIPTION
#379

Closes #379


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scope identifier handling to prevent unintended overwrites. When updating existing scopes, identifiers are now correctly preserved instead of being replaced. This resolves data integrity issues during scope modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->