### PR TITLE
feat(core): use disableExternalLoggerConfiguration in logger service

### DIFF
--- a/fido2/model/src/main/java/org/gluu/fido2/model/conf/AppConfiguration.java
+++ b/fido2/model/src/main/java/org/gluu/fido2/model/conf/AppConfiguration.java
@@ -37,6 +37,8 @@ public class AppConfiguration implements Configuration {
     private boolean useLocalCache;
 	@DocProperty(description = "Boolean value specifying whether to enable JDK Loggers")
     private boolean disableJdkLogger = true;
+	@DocProperty(description = "Boolean value specifying whether to enable external log4j configuration")
+    private Boolean disableExternalLoggerConfiguration = true;
 	@DocProperty(description = "Logging level for Fido2 logger")
     private String loggingLevel;
 	@DocProperty(description = "Logging layout used for Fido2")
@@ -108,6 +110,14 @@ public class AppConfiguration implements Configuration {
 
 	public void setDisableJdkLogger(Boolean disableJdkLogger) {
 		this.disableJdkLogger = disableJdkLogger;
+	}
+
+	public Boolean getDisableExternalLoggerConfiguration() {
+		return disableExternalLoggerConfiguration;
+	}
+
+	public void setDisableExternalLoggerConfiguration(Boolean disableExternalLoggerConfiguration) {
+		this.disableExternalLoggerConfiguration = disableExternalLoggerConfiguration;
 	}
 
 	public String getLoggingLevel() {

--- a/fido2/server/src/main/java/org/gluu/fido2/service/shared/LoggerService.java
+++ b/fido2/server/src/main/java/org/gluu/fido2/service/shared/LoggerService.java
@@ -23,6 +23,11 @@ public class LoggerService extends org.gluu.service.logger.LoggerService {
         return appConfiguration.getDisableJdkLogger() != null && appConfiguration.getDisableJdkLogger();
     }
 
+	@Override
+	public boolean isDisableExternalLoggerConfiguration() {
+		return (appConfiguration.getDisableExternalLoggerConfiguration() != null) && appConfiguration.getDisableExternalLoggerConfiguration();
+	}
+
     @Override
     public String getLoggingLevel() {
         return appConfiguration.getLoggingLevel();

--- a/oxAuth/Model/src/main/java/org/gluu/oxauth/model/configuration/AppConfiguration.java
+++ b/oxAuth/Model/src/main/java/org/gluu/oxauth/model/configuration/AppConfiguration.java
@@ -223,6 +223,7 @@ public class AppConfiguration implements Configuration {
     private Boolean logClientIdOnClientAuthentication;
     private Boolean logClientNameOnClientAuthentication;
     private Boolean disableJdkLogger = true;
+    private Boolean disableExternalLoggerConfiguration = true;
     private Set<String> authorizationRequestCustomAllowedParameters;
     private Boolean legacyDynamicRegistrationScopeParam;
     private Boolean openidScopeBackwardCompatibility = false;
@@ -569,7 +570,15 @@ public class AppConfiguration implements Configuration {
         this.disableJdkLogger = disableJdkLogger;
     }
 
-    /**
+    public Boolean getDisableExternalLoggerConfiguration() {
+		return disableExternalLoggerConfiguration;
+	}
+
+	public void setDisableExternalLoggerConfiguration(Boolean disableExternalLoggerConfiguration) {
+		this.disableExternalLoggerConfiguration = disableExternalLoggerConfiguration;
+	}
+
+	/**
      * Used in ServletLoggingFilter to enable http request/response logging.
      */
     private Boolean httpLoggingEnabled;

--- a/oxAuth/Server/src/main/java/org/gluu/oxauth/service/logger/LoggerService.java
+++ b/oxAuth/Server/src/main/java/org/gluu/oxauth/service/logger/LoggerService.java
@@ -24,6 +24,11 @@ public class LoggerService extends org.gluu.service.logger.LoggerService {
         return ServerUtil.isTrue(appConfiguration.getDisableJdkLogger());
     }
 
+	@Override
+	public boolean isDisableExternalLoggerConfiguration() {
+		return (appConfiguration.getDisableExternalLoggerConfiguration() != null) && appConfiguration.getDisableExternalLoggerConfiguration();
+	}
+
     @Override
     public String getLoggingLevel() {
         return appConfiguration.getLoggingLevel();

--- a/oxCore/oxService/src/main/java/org/gluu/config/oxtrust/AppConfiguration.java
+++ b/oxCore/oxService/src/main/java/org/gluu/config/oxtrust/AppConfiguration.java
@@ -157,6 +157,7 @@ public class AppConfiguration implements Configuration, Serializable {
     private int metricReporterKeepDataDays;
     private Boolean metricReporterEnabled;
     private Boolean disableJdkLogger = true;
+    private Boolean disableExternalLoggerConfiguration = true;
 
     @JsonProperty("ScimProperties")
     private ScimProperties scimProperties;
@@ -904,7 +905,15 @@ public class AppConfiguration implements Configuration, Serializable {
         this.disableJdkLogger = disableJdkLogger;
     }
 
-    public int getPasswordResetRequestExpirationTime() {
+    public Boolean getDisableExternalLoggerConfiguration() {
+		return disableExternalLoggerConfiguration;
+	}
+
+	public void setDisableExternalLoggerConfiguration(Boolean disableExternalLoggerConfiguration) {
+		this.disableExternalLoggerConfiguration = disableExternalLoggerConfiguration;
+	}
+
+	public int getPasswordResetRequestExpirationTime() {
         return passwordResetRequestExpirationTime;
     }
 

--- a/oxCore/oxService/src/main/java/org/gluu/service/logger/LoggerService.java
+++ b/oxCore/oxService/src/main/java/org/gluu/service/logger/LoggerService.java
@@ -71,9 +71,8 @@ public abstract class LoggerService {
     }
 
     public void initTimer(boolean updateNow) {
-        if (isDisableConfigurationUpdate()) {
-        	return;
-        }
+    	// Log message if external log4j configuration will be used
+        isDisableConfigurationUpdate(false);
 
         log.info("Initializing Logger Update Timer");
 
@@ -93,7 +92,7 @@ public abstract class LoggerService {
 
     @Asynchronous
     public void updateLoggerTimerEvent(@Observes @Scheduled LoggerUpdateEvent loggerUpdateEvent) {
-        if (isDisableConfigurationUpdate()) {
+        if (isDisableConfigurationUpdate(true)) {
         	return;
         }
 
@@ -118,7 +117,7 @@ public abstract class LoggerService {
 
     @Asynchronous
     public void updateLoggerSeverity(@Observes @ConfigurationUpdate Object appConfiguration) {
-        if (isDisableConfigurationUpdate()) {
+        if (isDisableConfigurationUpdate(true)) {
         	return;
         }
 
@@ -141,9 +140,20 @@ public abstract class LoggerService {
         }
     }
 
-	private boolean isDisableConfigurationUpdate() {
+	private boolean isDisableConfigurationUpdate(boolean silent) {
+		if (isDisableExternalLoggerConfiguration()) {
+			if (!silent) {
+				if (System.getProperty(OVERRIDE_JAVA_PROPERTY) != null) {
+					log.info("Property log4j2.configurationFile is specifed. Ignoring it according to \"disableExternalLoggerConfiguration\" configuration property");
+				}
+			}
+			return false;
+		}
+
 		if (System.getProperty(OVERRIDE_JAVA_PROPERTY) != null) {
-            log.info("Property log4j2.configurationFile is specifed. Update configuration is turned off");
+			if (!silent) {
+				log.info("Property log4j2.configurationFile is specifed. Update configuration is turned off");
+			}
             return true;
         }
 
@@ -403,10 +413,12 @@ public abstract class LoggerService {
 
     public abstract boolean isDisableJdkLogger();
 
+    public abstract boolean isDisableExternalLoggerConfiguration();
+
     public abstract String getLoggingLevel();
 
     public abstract String getLoggingLayout();
-    
+
     public abstract String getExternalLoggerConfiguration();
 
 }

--- a/oxTrust/server/src/main/java/org/gluu/oxtrust/service/logger/LoggerService.java
+++ b/oxTrust/server/src/main/java/org/gluu/oxtrust/service/logger/LoggerService.java
@@ -27,6 +27,11 @@ public class LoggerService extends org.gluu.service.logger.LoggerService {
         return (appConfiguration.getDisableJdkLogger() != null) && appConfiguration.getDisableJdkLogger();
     }
 
+	@Override
+	public boolean isDisableExternalLoggerConfiguration() {
+		return (appConfiguration.getDisableExternalLoggerConfiguration() != null) && appConfiguration.getDisableExternalLoggerConfiguration();
+	}
+
     @Override
     public String getLoggingLevel() {
         return appConfiguration.getLoggingLevel();

--- a/oxTrust/static/src/main/resources/META-INF/resources/schema/fido2-config.json
+++ b/oxTrust/static/src/main/resources/META-INF/resources/schema/fido2-config.json
@@ -50,6 +50,11 @@
          "description":"Boolean value specifying whether to enable JDK Loggers.",
          "type":"boolean"
       },
+      "disableExternalLoggerConfiguration": {
+         "id": "disableExternalLoggerConfiguration",
+         "description": "Boolean value specifying whether to enable external log4j configuration.",
+         "type": "boolean"
+      },
       "loggingLevel":{
          "id":"loggingLevel",
          "description":"Logging level for oxAuth logers.",
@@ -293,6 +298,7 @@
       "cleanServiceBatchChunkSize",
       "useLocalCache",
       "disableJdkLogger",
+      "disableExternalLoggerConfiguration",
       "loggingLevel",
       "loggingLayout",
       "externalLoggerConfiguration",

--- a/oxTrust/static/src/main/resources/META-INF/resources/schema/oxauth-config.xml.json
+++ b/oxTrust/static/src/main/resources/META-INF/resources/schema/oxauth-config.xml.json
@@ -1507,6 +1507,11 @@
             "description": "Boolean value specifying whether to enable JDK Loggers.",
             "type": "boolean"
         },
+        "disableExternalLoggerConfiguration": {
+            "id": "disableExternalLoggerConfiguration",
+            "description": "Boolean value specifying whether to enable external log4j configuration.",
+            "type": "boolean"
+        },
         "jmsUserName": {
             "id": "jmsUserName",
             "description": "JMS UserName.",
@@ -2013,6 +2018,7 @@
         "loggingLevel",
         "loggingLayout",
         "disableJdkLogger",
+        "disableExternalLoggerConfiguration",
         "corsConfigurationFilters",
         "logClientIdOnClientAuthentication",
         "logClientNameOnClientAuthentication",

--- a/oxTrust/static/src/main/resources/META-INF/resources/schema/oxtrust.properties.json
+++ b/oxTrust/static/src/main/resources/META-INF/resources/schema/oxtrust.properties.json
@@ -632,6 +632,11 @@
             "description": "Boolean value specifying whether to enable JDK Loggers.",
             "type": "boolean"
         },
+        "disableExternalLoggerConfiguration": {
+            "id": "disableExternalLoggerConfiguration",
+            "description": "Boolean value specifying whether to enable external log4j configuration.",
+            "type": "boolean"
+        },
         "passwordResetRequestExpirationTime": {
             "id": "passwordResetRequestExpirationTime",
             "description": "Expiration time in seconds for password reset requests.",
@@ -774,6 +779,7 @@
         "loggingLevel",
         "loggingLayout",
         "disableJdkLogger",
+        "disableExternalLoggerConfiguration",
         "cleanServiceInterval",
         "passwordResetRequestExpirationTime",
         "authenticationRecaptchaEnabled",

--- a/scim/scim-server/src/main/java/org/gluu/oxtrust/service/logger/LoggerService.java
+++ b/scim/scim-server/src/main/java/org/gluu/oxtrust/service/logger/LoggerService.java
@@ -20,6 +20,11 @@ public class LoggerService extends org.gluu.service.logger.LoggerService {
         return (appConfiguration.getDisableJdkLogger() != null) && appConfiguration.getDisableJdkLogger();
     }
 
+	@Override
+	public boolean isDisableExternalLoggerConfiguration() {
+		return (appConfiguration.getDisableExternalLoggerConfiguration() != null) && appConfiguration.getDisableExternalLoggerConfiguration();
+	}
+
     @Override
     public String getLoggingLevel() {
         return appConfiguration.getLoggingLevel();


### PR DESCRIPTION
#327

Closes #327


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new configuration property enabling administrators to control external logger configuration handling. This boolean setting allows management of whether external Log4j configurations are applied across FIDO2, oxAuth, oxTrust, and SCIM modules, providing enhanced flexibility over system logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->