### PR TITLE
chore(oxauth): upgraded nimbus-jose-jwt to 10.0.2 #385

### DIFF
--- a/gluu-core-bom/pom.xml
+++ b/gluu-core-bom/pom.xml
@@ -274,7 +274,7 @@
 			<dependency>
 				<groupId>com.nimbusds</groupId>
 				<artifactId>nimbus-jose-jwt</artifactId>
-				<version>9.48</version>
+				<version>10.0.2</version>
 			</dependency>
 
 			<!-- Weld -->


### PR DESCRIPTION
**Issue**

chore(oxauth): upgraded nimbus-jose-jwt to 10.0.2

Closes #385

Validated it after migration with cross check test.

<img width="2150" height="1502" alt="Image" src="https://github.com/user-attachments/assets/932c9f13-39ec-4ac1-bbaa-9bbd48114555" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated JWT authentication library dependency from version 9.48 to 10.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->