### PR TITLE
Add APT authentication configuration instructions

### DIFF
--- a/docs-gluu-server-prod/docs/source/installation-guide/install-ubuntu.md
+++ b/docs-gluu-server-prod/docs/source/installation-guide/install-ubuntu.md
@@ -36,9 +36,9 @@ echo "deb https://repo.gluu.org/ubuntu/ jammy main" > /etc/apt/sources.list.d/gl
 curl --user "your-username:your-password" https://repo.gluu.org/ubuntu/gluu-apt.key | apt-key add -
 ```
 
-```
 Create a file named /etc/apt/auth.conf.d/99repo with content:
 
+```
 machine https://repo.gluu.org
 login your-username
 password your-password


### PR DESCRIPTION
Added instructions to create an auth.conf.d file for APT.

**Issue**
<!-- Please link the issue here -->
Closes #

**Work scope**
<!-- Please mark the areas that need to be worked on. -->
- [ ] Services
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Other

**Describe the bug/Feature**
<!-- A clear and concise description of what the bug is. -->

**If this is a bug how can it be reproduced**

Steps to reproduce the behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See error

**Expected behavior**
<!-- A clear and concise description of what you expected to happen. -->

**Screenshots**
<!-- If applicable, add screenshots to help explain. -->

**Additional context**
<!-- Add any other context about the problem here. -->

**Work scope progress**

Please select the scopes that are completed. This must match the work scope above by the end of the development.

- [ ] Services
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Ubuntu installation guide with explicit authentication file configuration content, replacing placeholder instructions with concrete examples for both standard and Ubuntu 20.x installation paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->