### PR TITLE
feat(orm): add option to check data in DB after entry update

### DIFF
--- a/oxOrm/core/src/main/java/org/gluu/persist/impl/BaseEntryManager.java
+++ b/oxOrm/core/src/main/java/org/gluu/persist/impl/BaseEntryManager.java
@@ -238,12 +238,13 @@ public abstract class BaseEntryManager<O extends PersistenceOperationService> im
 
 		// Load entry
 		List<AttributeData> attributesFromLdap = null;
+		List<String> currentLdapReturnAttributesList = null;
 		if (isSchemaUpdate || forceUpdate) {
 			// If it's schema modification request we don't need to load
 			// attributes from LDAP
 			attributesFromLdap = new ArrayList<AttributeData>();
 		} else {
-			List<String> currentLdapReturnAttributesList = buildAttributesListForUpdate(entry, objectClasses, propertiesAnnotations);
+			currentLdapReturnAttributesList = buildAttributesListForUpdate(entry, objectClasses, propertiesAnnotations);
 			if (!isConfigurationUpdate) {
 				currentLdapReturnAttributesList.add("objectClass");
 			}
@@ -256,6 +257,36 @@ public abstract class BaseEntryManager<O extends PersistenceOperationService> im
 			dumpAttributes("attributesToPersist", attributesToPersist);
 		}
 
+		List<AttributeDataModification> attributeDataModifications = prepareAttributeDataModifications(entryClass, dnValue,
+				entry, propertiesAnnotations, attributesToPersistMap, attributesFromLdap, schemaModificationType, isSchemaUpdate,
+				isConfigurationUpdate, forceUpdate);
+
+		merge(dnValue.toString(), objectClasses, attributeDataModifications, expirationValue);
+		
+		if (isValidateAfterUpdate()) {
+			if (!isSchemaUpdate) {
+				// Compare loaded entry data after merge
+				List<AttributeData> attributesAfterMergeFromLdap = find(dnValue.toString(), objectClasses, propertiesAnnotationsMap, currentLdapReturnAttributesList.toArray(EMPTY_STRING_ARRAY));
+
+				// Compare loaded entry data with initial entry data
+				List<AttributeDataModification> attributeDataModificationsAftermerge = prepareAttributeDataModifications(entryClass,
+						dnValue, entry, propertiesAnnotations, attributesToPersistMap, attributesAfterMergeFromLdap, schemaModificationType,
+						isSchemaUpdate, isConfigurationUpdate, forceUpdate);
+
+				if (attributeDataModificationsAftermerge.size() > 0) {
+					LOG.warn("Detected changes which not exists in enry after merge. Entry DN: %s, missing changes: "
+							+ attributeDataModificationsAftermerge);
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private List<AttributeDataModification> prepareAttributeDataModifications(Class<?> entryClass, Object dnValue,
+			Object entry, List<PropertyAnnotation> propertiesAnnotations, Map<String, AttributeData> attributesToPersistMap,
+			List<AttributeData> attributesFromLdap, AttributeModificationType schemaModificationType, boolean isSchemaUpdate,
+			boolean isConfigurationUpdate, boolean forceUpdate) {
 		Map<String, AttributeData> attributesFromLdapMap = getAttributesMap(attributesFromLdap);
 
 		// Prepare list of modifications
@@ -277,9 +308,7 @@ public abstract class BaseEntryManager<O extends PersistenceOperationService> im
 
 		LOG.debug(String.format("LDAP attributes for merge: %s", attributeDataModifications));
 
-		merge(dnValue.toString(), objectClasses, attributeDataModifications, expirationValue);
-
-		return null;
+		return attributeDataModifications;
 	}
 
 	protected List<String> buildAttributesListForUpdate(Object entry, String[] objectClasses, List<PropertyAnnotation> propertiesAnnotations) {
@@ -2382,4 +2411,9 @@ public abstract class BaseEntryManager<O extends PersistenceOperationService> im
 
 		return sb.toString();
 	}
+
+	protected boolean isValidateAfterUpdate() {
+		return false;
+	}
+
 }

--- a/oxOrm/core/src/main/java/org/gluu/persist/impl/BaseEntryManager.java
+++ b/oxOrm/core/src/main/java/org/gluu/persist/impl/BaseEntryManager.java
@@ -266,9 +266,14 @@ public abstract class BaseEntryManager<O extends PersistenceOperationService> im
 		if (isValidateAfterUpdate()) {
 			if (!isSchemaUpdate) {
 				// Compare loaded entry data after merge
+				
+				// Step 1. Rebuild map with attributes which we planned to persist
+				attributesToPersistMap = getAttributesMap(attributesToPersist);
+
+				// Step 2. Load current entry from DB
 				List<AttributeData> attributesAfterMergeFromLdap = find(dnValue.toString(), objectClasses, propertiesAnnotationsMap, currentLdapReturnAttributesList.toArray(EMPTY_STRING_ARRAY));
 
-				// Compare loaded entry data with initial entry data
+				// Step 3. Compare loaded entry data with initial entry data
 				List<AttributeDataModification> attributeDataModificationsAftermerge = prepareAttributeDataModifications(entryClass,
 						dnValue, entry, propertiesAnnotations, attributesToPersistMap, attributesAfterMergeFromLdap, schemaModificationType,
 						isSchemaUpdate, isConfigurationUpdate, forceUpdate);

--- a/oxOrm/core/src/main/java/org/gluu/persist/model/AttributeData.java
+++ b/oxOrm/core/src/main/java/org/gluu/persist/model/AttributeData.java
@@ -82,10 +82,10 @@ public class AttributeData {
 		if (obj == null)
 			return false;
 		AttributeData other = (AttributeData) obj;
-		if ((multiValued != null) && (other.multiValued != null)) {
-			if (!multiValued.equals(other.multiValued))
-				return false;
-		}
+//		if ((multiValued != null) && (other.multiValued != null)) {
+//			if (!multiValued.equals(other.multiValued))
+//				return false;
+//		}
 		if (name == null) {
 			if (other.name != null)
 				return false;

--- a/oxOrm/sql/src/main/java/org/gluu/persist/sql/impl/SqlEntryManager.java
+++ b/oxOrm/sql/src/main/java/org/gluu/persist/sql/impl/SqlEntryManager.java
@@ -17,8 +17,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import javax.inject.Inject;
-
 import org.gluu.orm.util.ArrayHelper;
 import org.gluu.orm.util.StringHelper;
 import org.gluu.persist.PersistenceEntryManager;
@@ -54,6 +52,8 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.Expressions;
 
+import jakarta.inject.Inject;
+
 /**
  * SQL Entry Manager
  *
@@ -76,10 +76,13 @@ public class SqlEntryManager extends BaseEntryManager<SqlOperationService> imple
 
     private List<DeleteNotifier> subscribers;
 
+	private boolean validateAfterUpdate;
+
     protected SqlEntryManager(SqlOperationService operationService) {
         this.operationService = operationService;
         this.filterConverter = new SqlFilterConverter(operationService);
         subscribers = new LinkedList<DeleteNotifier>();
+        this.validateAfterUpdate = operationService.getConnectionProvider().isValidateAfterUpdate();
     }
 
     @Override
@@ -1003,6 +1006,11 @@ public class SqlEntryManager extends BaseEntryManager<SqlOperationService> imple
 		}
 		
 		return objectClasses[0];
+	}
+
+    @Override
+	protected boolean isValidateAfterUpdate() {
+		return validateAfterUpdate;
 	}
 
 }

--- a/oxOrm/sql/src/main/java/org/gluu/persist/sql/impl/SqlEntryManager.java
+++ b/oxOrm/sql/src/main/java/org/gluu/persist/sql/impl/SqlEntryManager.java
@@ -52,7 +52,7 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.Expressions;
 
-import jakarta.inject.Inject;
+import javax.inject.Inject;
 
 /**
  * SQL Entry Manager

--- a/oxOrm/sql/src/main/java/org/gluu/persist/sql/operation/impl/SqlConnectionProvider.java
+++ b/oxOrm/sql/src/main/java/org/gluu/persist/sql/operation/impl/SqlConnectionProvider.java
@@ -91,6 +91,8 @@ public class SqlConnectionProvider {
 	private Map<String, String> tableEnginesMap = new HashMap<>();
 	private Map<String, ArrayList<String>> tableJsonColumnsMap = new HashMap<>();
 
+	private boolean validateAfterUpdate;
+
     protected SqlConnectionProvider() {
     }
 
@@ -179,6 +181,11 @@ public class SqlConnectionProvider {
 		Boolean testOnReturn = StringHelper.toBoolean(props.getProperty("connection.pool.test-on-return"), null);
 		if (testOnReturn != null) {
 			objectPoolConfig.setTestOnReturn(testOnReturn);
+		}
+
+		Boolean validateAfterUpdate = StringHelper.toBoolean(props.getProperty("orm.validate-after-update"), null);
+		if (validateAfterUpdate != null) {
+			this.validateAfterUpdate = validateAfterUpdate.booleanValue();
 		}
 
         openWithWaitImpl();
@@ -508,6 +515,10 @@ public class SqlConnectionProvider {
 
 	public SupportedDbType getDbType() {
 		return dbType;
+	}
+
+	public boolean isValidateAfterUpdate() {
+		return validateAfterUpdate;
 	}
 
 }


### PR DESCRIPTION
#410

Closes #410


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional post-update data validation to verify database entry consistency after modifications. Disabled by default and controlled via configuration.

* **Configuration**
  * New configuration flag `orm.validate-after-update` for enabling data validation after database updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->