### PR TITLE
Add instructions for issuerId and entityId in README

### DIFF
--- a/oxAuth/Server/integrations/Per-SP-ACR-Routing/README.md
+++ b/oxAuth/Server/integrations/Per-SP-ACR-Routing/README.md
@@ -100,6 +100,11 @@ entityid_oidc_acr_map_file = /etc/certs/saml2oidc_acr_mappings.json
 
 Edit config:
 
+ - Log into Gluu Server oxTrust
+ - JSON Configuration > oxAuth Configuration > Search for "authorizationRequestCustomAllowedParameters"
+ - Add `issuerId` as Item_1 and "entityId" as Item_2
+ - Update property
+
 ```json
 "authorizationRequestCustomAllowedParameters": [
   "issuerId",


### PR DESCRIPTION
Updated README to include instructions for allowing issuerId and entityId in oxAuth configuration.

**Issue**
<!-- Please link the issue here -->
Closes #

**Work scope**
<!-- Please mark the areas that need to be worked on. -->
- [ ] Services
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Other

**Describe the bug/Feature**
<!-- A clear and concise description of what the bug is. -->

**If this is a bug how can it be reproduced**

Steps to reproduce the behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See error

**Expected behavior**
<!-- A clear and concise description of what you expected to happen. -->

**Screenshots**
<!-- If applicable, add screenshots to help explain. -->

**Additional context**
<!-- Add any other context about the problem here. -->

**Work scope progress**

Please select the scopes that are completed. This must match the work scope above by the end of the development.

- [ ] Services
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added configuration guide for adding custom parameters to oxAuth authorization request settings, including step-by-step instructions for modifying configuration settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->