### PR TITLE
feat(oxauth): added ability to specify prefix for cache entries (via cache configuration property) #433

### DIFF
--- a/oxCore/core-cache/src/main/java/org/gluu/service/BaseCacheService.java
+++ b/oxCore/core-cache/src/main/java/org/gluu/service/BaseCacheService.java
@@ -5,6 +5,7 @@
  */
 package org.gluu.service;
 
+import org.apache.commons.lang3.StringUtils;
 import org.gluu.service.cache.CacheInterface;
 import org.gluu.service.cache.CacheProvider;
 import org.gluu.service.cache.CacheProviderType;
@@ -34,11 +35,21 @@ public abstract class BaseCacheService implements CacheInterface {
             return null;
         }
 
-    	log.trace("Request data, key '{}'", key);
+        key = addKeyPrefix(key, cacheProvider);
+
+        log.trace("Request data, key '{}'", key);
     	Object value = cacheProvider.get(key);
     	log.trace("Loaded data, key '{}': '{}'", key, value);
 
     	return value;
+    }
+
+    private static String addKeyPrefix(String key, CacheProvider cacheProvider) {
+        String keyPrefix = cacheProvider.getCacheConfiguration().getKeyPrefix();
+        if (StringUtils.isNotBlank(keyPrefix) && !key.startsWith(keyPrefix)) {
+            key = keyPrefix + key;
+        }
+        return key;
     }
 
     public <T> T getWithPut(String key, Supplier<T> loadFunction, int expirationInSeconds) {
@@ -47,6 +58,8 @@ public abstract class BaseCacheService implements CacheInterface {
         }
 
     	CacheProvider cacheProvider = getCacheProvider();
+
+        key = addKeyPrefix(key, cacheProvider);
 
     	if (CacheProviderType.NATIVE_PERSISTENCE == cacheProvider.getProviderType()) {
         	log.trace("Loading data from DB without cache, key '{}'", key);
@@ -80,7 +93,9 @@ public abstract class BaseCacheService implements CacheInterface {
         	log.error("Cache provider is invalid!");
 			return;
 		}
-		
+
+        key = addKeyPrefix(key, cacheProvider);
+
     	log.trace("Put data, key '{}': '{}'", key, object);
 		cacheProvider.put(expirationInSeconds, key, object);
 	}
@@ -91,7 +106,8 @@ public abstract class BaseCacheService implements CacheInterface {
         	log.error("Cache provider is invalid!");
 			return;
 		}
-		
+
+        key = addKeyPrefix(key, cacheProvider);
     	log.trace("Remove data, key '{}'", key);
 		cacheProvider.remove(key);
 	}

--- a/oxCore/core-cache/src/main/java/org/gluu/service/cache/CacheConfiguration.java
+++ b/oxCore/core-cache/src/main/java/org/gluu/service/cache/CacheConfiguration.java
@@ -26,6 +26,8 @@ public class CacheConfiguration implements Serializable {
 
     private NativePersistenceConfiguration nativePersistenceConfiguration;
 
+    private String keyPrefix;
+
     public NativePersistenceConfiguration getNativePersistenceConfiguration() {
         return nativePersistenceConfiguration;
     }
@@ -66,6 +68,14 @@ public class CacheConfiguration implements Serializable {
         this.memcachedConfiguration = memcachedConfiguration;
     }
 
+    public String getKeyPrefix() {
+        return keyPrefix;
+    }
+
+    public void setKeyPrefix(String keyPrefix) {
+        this.keyPrefix = keyPrefix;
+    }
+
     @Override
     public String toString() {
         return "CacheConfiguration{" +
@@ -74,6 +84,7 @@ public class CacheConfiguration implements Serializable {
                 ", redisConfiguration=" + redisConfiguration +
                 ", inMemoryConfiguration=" + inMemoryConfiguration +
                 ", nativePersistenceConfiguration=" + nativePersistenceConfiguration +
+                ", keyPrefix=" + keyPrefix +
                 '}';
     }
 }

--- a/oxCore/core-cache/src/main/java/org/gluu/service/cache/CacheProvider.java
+++ b/oxCore/core-cache/src/main/java/org/gluu/service/cache/CacheProvider.java
@@ -45,4 +45,6 @@ public abstract class CacheProvider<T> implements CacheInterface {
 	
 	public abstract CacheProviderType getProviderType();
 
+    public abstract CacheConfiguration getCacheConfiguration();
+
 }

--- a/oxCore/core-cache/src/main/java/org/gluu/service/cache/InMemoryCacheProvider.java
+++ b/oxCore/core-cache/src/main/java/org/gluu/service/cache/InMemoryCacheProvider.java
@@ -106,4 +106,8 @@ public class InMemoryCacheProvider extends AbstractCacheProvider<ExpiringMap> {
         return CacheProviderType.IN_MEMORY;
     }
 
+    @Override
+    public CacheConfiguration getCacheConfiguration() {
+        return cacheConfiguration;
+    }
 }

--- a/oxCore/core-cache/src/main/java/org/gluu/service/cache/MemcachedProvider.java
+++ b/oxCore/core-cache/src/main/java/org/gluu/service/cache/MemcachedProvider.java
@@ -151,4 +151,8 @@ public class MemcachedProvider extends AbstractCacheProvider<MemcachedClient> {
         return CacheProviderType.MEMCACHED;
     }
 
+    @Override
+    public CacheConfiguration getCacheConfiguration() {
+        return cacheConfiguration;
+    }
 }

--- a/oxCore/core-cache/src/main/java/org/gluu/service/cache/NativePersistenceCacheProvider.java
+++ b/oxCore/core-cache/src/main/java/org/gluu/service/cache/NativePersistenceCacheProvider.java
@@ -312,7 +312,12 @@ public class NativePersistenceCacheProvider extends AbstractCacheProvider<Persis
     public void setCacheConfiguration(CacheConfiguration cacheConfiguration) {
         this.cacheConfiguration = cacheConfiguration;
     }
-    
+
+    @Override
+    public CacheConfiguration getCacheConfiguration() {
+        return cacheConfiguration;
+    }
+
     public static void main(String[] args) {
 		NativePersistenceCacheProvider cp = new NativePersistenceCacheProvider();
 		Object obj = cp.fromString("rO0ABXNyAClvcmcuZ2x1dS5veGF1dGgubW9kZWwuY29tbW9uLkNsaWVudFRva2Vuc/Aib54fThHVAgACTAAIY2xpZW50SWR0ABJMamF2YS9sYW5nL1N0cmluZztMAAt0b2tlbkhhc2hlc3QAD0xqYXZhL3V0aWwvU2V0O3hwdAApMTAwMS45MGQ0MGI2OS02ZDFmLTQxMmYtOTg5ZS00MThmN2E2Y2M1MTNzcgARamF2YS51dGlsLkhhc2hTZXS6RIWVlri3NAMAAHhwdwwAAAAQP0AAAAAAAAF0AEA3M2M1NDBhYjRlNzU2ZTk2ZjQ2NzU2ODZjNzU0ZDg1ZjZiOWExYmI0ZjI1ZWY5NTZjYmRkZTQ0NjlmZTA2OGVjeA==");

--- a/oxCore/core-cache/src/main/java/org/gluu/service/cache/RedisProvider.java
+++ b/oxCore/core-cache/src/main/java/org/gluu/service/cache/RedisProvider.java
@@ -129,4 +129,8 @@ public class RedisProvider extends AbstractCacheProvider<AbstractRedisProvider> 
         return CacheProviderType.REDIS;
     }
 
+    @Override
+    public CacheConfiguration getCacheConfiguration() {
+        return cacheConfiguration;
+    }
 }


### PR DESCRIPTION
**Issue**

feat(oxauth): added ability to specify prefix for cache entries (via cache configuration property) 

Closes #433



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cache operations now support configurable key prefixing to normalize and isolate cached data.

* **Refactor**
  * Exposed cache configuration accessors across all cache provider implementations to enable programmatic retrieval of configuration settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->