### PR TITLE
feat(oxauth): added ability to specify clientName for redis connection via AS configuration property #432

### DIFF
--- a/oxCore/core-cache/src/main/java/org/gluu/service/cache/RedisClusterProvider.java
+++ b/oxCore/core-cache/src/main/java/org/gluu/service/cache/RedisClusterProvider.java
@@ -11,7 +11,6 @@ import redis.clients.jedis.JedisPoolConfig;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.UUID;
 
 /**
  * Important : keep it weld free. It's reused by oxd !
@@ -30,7 +29,7 @@ public class RedisClusterProvider extends AbstractRedisProvider {
 
     public void create() {
         try {
-            LOG.debug("Starting RedisClusterProvider ... configuration:" + getRedisConfiguration());
+            LOG.debug("Starting RedisClusterProvider ... configuration:" + redisConfiguration);
 
             JedisPoolConfig poolConfig = createPoolConfig();
             String password = redisConfiguration.getPassword();
@@ -40,10 +39,11 @@ public class RedisClusterProvider extends AbstractRedisProvider {
 
                 pool = new JedisCluster(hosts(getRedisConfiguration().getServers()), redisConfiguration.getConnectionTimeout(),
                         redisConfiguration.getSoTimeout(), redisConfiguration.getMaxRetryAttempts(),
-                        password, UUID.randomUUID().toString(), poolConfig, true);
+                        password, redisConfiguration.getClientName(), poolConfig, true);
             } else {
                 pool = new JedisCluster(hosts(getRedisConfiguration().getServers()), redisConfiguration.getConnectionTimeout(),
-                        redisConfiguration.getSoTimeout(), redisConfiguration.getMaxRetryAttempts(), password, poolConfig);
+                        redisConfiguration.getSoTimeout(), redisConfiguration.getMaxRetryAttempts(),
+                        password, redisConfiguration.getClientName(), poolConfig);
             }
 
             testConnection();

--- a/oxCore/core-cache/src/main/java/org/gluu/service/cache/RedisConfiguration.java
+++ b/oxCore/core-cache/src/main/java/org/gluu/service/cache/RedisConfiguration.java
@@ -4,6 +4,7 @@ package org.gluu.service.cache;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.io.Serializable;
+import java.util.UUID;
 
 /**
  * @author yuriyz on 02/23/2017.
@@ -22,6 +23,8 @@ public class RedisConfiguration implements Serializable {
     private String sentinelMasterGroupName = "";
 
     private String password;
+
+    private String clientName = UUID.randomUUID().toString();
 
     private Boolean useSSL = false;
 
@@ -57,6 +60,14 @@ public class RedisConfiguration implements Serializable {
     private int soTimeout = 3000;
 
     private int maxRetryAttempts = 5;
+
+    public String getClientName() {
+        return clientName;
+    }
+
+    public void setClientName(String clientName) {
+        this.clientName = clientName;
+    }
 
     public int getMaxIdleConnections() {
         return maxIdleConnections;
@@ -193,6 +204,7 @@ public class RedisConfiguration implements Serializable {
                 ", connectionTimeout=" + connectionTimeout +
                 ", soTimeout=" + soTimeout +
                 ", maxRetryAttempts=" + maxRetryAttempts +
+                ", clientName=" + clientName +
                 '}';
     }
 }


### PR DESCRIPTION
**Issue**

feat(oxauth): added ability to specify clientName for redis connection via AS configuration property #432

Closes #432



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable client name for Redis cluster connections, enabling better identification and monitoring of Redis clients.

* **Improvements**
  * Enhanced Redis cluster initialization to use configuration-based client naming instead of auto-generated identifiers, improving traceability and operational visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->